### PR TITLE
feat: Customize Django admin interface

### DIFF
--- a/raffles/admin.py
+++ b/raffles/admin.py
@@ -1,6 +1,10 @@
 from django.contrib import admin
 from .models import Customer, Raffle, Ticket, TicketTemplate
 
+admin.site.site_header = "Raffles Admin"
+admin.site.site_title = "Raffles Admin Portal"
+admin.site.index_title = "Welcome to Raffles Admin Portal"
+
 @admin.register(TicketTemplate)
 class TicketTemplateAdmin(admin.ModelAdmin):
     list_display = ('name', 'background_color', 'font_color', 'created_at')

--- a/raffles/static/img/favicon.svg
+++ b/raffles/static/img/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-ticket-fill" viewBox="0 0 16 16">
+  <path d="M1.5 3A1.5 1.5 0 0 0 0 4.5V6a.5.5 0 0 0 .5.5 1.5 1.5 0 1 1 0 3 .5.5 0 0 0-.5.5v1.5A1.5 1.5 0 0 0 1.5 13h13a1.5 1.5 0 0 0 1.5-1.5V10a.5.5 0 0 0-.5-.5 1.5 1.5 0 1 1 0-3 .5.5 0 0 0 .5-.5V4.5A1.5 1.5 0 0 0 14.5 3h-13Z"/>
+</svg>

--- a/raffles/templates/admin/base_site.html
+++ b/raffles/templates/admin/base_site.html
@@ -1,0 +1,6 @@
+{% extends "admin/base_site.html" %}
+{% load static %}
+
+{% block extrahead %}{{ block.super }}
+    <link rel="shortcut icon" type="image/svg+xml" href="{% static 'img/favicon.svg' %}">
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ django
 python-decouple
 psycopg2-binary
 gunicorn
+Pillow


### PR DESCRIPTION
This commit customizes the Django admin interface by:
- Changing the site header, title, and index title.
- Adding a custom favicon.
- Adding Pillow to the project dependencies.