### PR TITLE
Refactor: Rename Dolibarr trigger class to InterfaceRafflesTrigger (C…

### DIFF
--- a/dolibarr_module/raffles/core/triggers/interface_20_modRaffles_RafflesTrigger.class.php
+++ b/dolibarr_module/raffles/core/triggers/interface_20_modRaffles_RafflesTrigger.class.php
@@ -6,7 +6,11 @@
  *  \brief      Trigger for Raffles module
  */
 
-class interface_20_modRaffles_RafflesTrigger
+/**
+ * Class InterfaceRafflesTrigger
+ * Standard Dolibarr trigger class name convention (CamelCase)
+ */
+class InterfaceRafflesTrigger
 {
     public $name = 'RafflesTrigger';
     public $family = 'raffles';
@@ -132,7 +136,7 @@ class interface_20_modRaffles_RafflesTrigger
 }
 
 /**
- * Class InterfaceRafflesTrigger
- * Alias for backward compatibility or ghost file issues
+ * Class interface_20_modRaffles_RafflesTrigger
+ * Backward compatibility alias for legacy file naming
  */
-class InterfaceRafflesTrigger extends interface_20_modRaffles_RafflesTrigger {}
+class interface_20_modRaffles_RafflesTrigger extends InterfaceRafflesTrigger {}


### PR DESCRIPTION
…amelCase)

Renamed the main trigger class to `InterfaceRafflesTrigger` to strictly follow Dolibarr's naming conventions and avoid "Class not found" errors when Dolibarr auto-discovers triggers. Kept `interface_20_modRaffles_RafflesTrigger` as an alias for backward compatibility.