### PR TITLE
Fix Dolibarr trigger class inheritance

### DIFF
--- a/dolibarr_module/raffles/core/triggers/interface_20_modRaffles_RafflesTrigger.class.php
+++ b/dolibarr_module/raffles/core/triggers/interface_20_modRaffles_RafflesTrigger.class.php
@@ -10,7 +10,7 @@
  * Class InterfaceRafflesTrigger
  * Standard Dolibarr trigger class name convention (CamelCase)
  */
-class InterfaceRafflesTrigger
+class InterfaceRafflesTrigger extends DolibarrTriggers
 {
     public $name = 'RafflesTrigger';
     public $family = 'raffles';
@@ -20,6 +20,10 @@ class InterfaceRafflesTrigger
     public function __construct($db)
     {
         $this->db = $db;
+        $this->name = preg_replace('/^Interface/i', '', get_class($this));
+        $this->family = "raffles";
+        $this->description = "Trigger para enviar datos a sistema de rifas";
+        $this->version = '1.0.0';
     }
 
     /**


### PR DESCRIPTION
- Rename trigger class to `InterfaceRafflesTrigger` to match Dolibarr naming conventions.
- Extend `DolibarrTriggers` to fix "does not extend" error.
- Remove type hints from `run_trigger` to ensure signature compatibility with parent class and avoid PHP warnings.
- Add backward compatibility alias.