### PR TITLE
Remove alias class from Dolibarr trigger file

### DIFF
--- a/dolibarr_module/raffles/core/triggers/interface_20_modRaffles_RafflesTrigger.class.php
+++ b/dolibarr_module/raffles/core/triggers/interface_20_modRaffles_RafflesTrigger.class.php
@@ -138,9 +138,3 @@ class InterfaceRafflesTrigger extends DolibarrTriggers
         return 0;
     }
 }
-
-/**
- * Class interface_20_modRaffles_RafflesTrigger
- * Backward compatibility alias for legacy file naming
- */
-class interface_20_modRaffles_RafflesTrigger extends InterfaceRafflesTrigger {}


### PR DESCRIPTION
- Removed the `interface_20_modRaffles_RafflesTrigger` alias class from `interface_20_modRaffles_RafflesTrigger.class.php`.
- The presence of this alias was causing the Dolibarr trigger loader to crash or fail silently, leading to an empty trigger list.
- The main class `InterfaceRafflesTrigger` remains, extending `DolibarrTriggers` with the correct `run_trigger` signature (no type hints).